### PR TITLE
Added spglib as a downloaded third party.

### DIFF
--- a/cmake/External_spglib.cmake
+++ b/cmake/External_spglib.cmake
@@ -1,0 +1,19 @@
+# An external project for spglib
+set(spglib_source  "${CMAKE_CURRENT_BINARY_DIR}/spglib-src")
+set(spglib_install "${OpenChemistry_INSTALL_PREFIX}")
+
+get_filename_component(_self_dir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+ExternalProject_Add(spglib
+  DOWNLOAD_DIR ${download_dir}
+  SOURCE_DIR "${spglib_source}"
+  INSTALL_DIR "${spglib_install}"
+  URL ${spglib_url}
+  URL_MD5 ${spglib_md5}
+  BUILD_IN_SOURCE 1
+  PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${_self_dir}/spglib.CMakeLists.txt"
+    "<SOURCE_DIR>/CMakeLists.txt"
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+)

--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -81,3 +81,10 @@ list(APPEND projects kdsoap)
 set(kdsoap_version "f3bbcf1e")
 set(kdsoap_url "${oc_download_base}/tpl/kdsoap-${kdsoap_version}.tar.gz")
 set(kdsoap_md5 "d2dcf62844d9e5919ba21788a375feca")
+
+# spglib
+list(APPEND projects spglib)
+set(spglib_version "1.9")
+set(spglib_version_micro "4")
+set(spglib_url "https://sourceforge.net/projects/spglib/files/spglib/spglib-${spglib_version}/spglib-${spglib_version}.${spglib_version_micro}.tar.gz/download")
+set(spglib_md5 "49efe9b583f799533108c027557557a3")

--- a/cmake/spglib.CMakeLists.txt
+++ b/cmake/spglib.CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 2.4.4)
+
+project(spglib C)
+
+set(SPGLIB_SRCS
+  src/arithmetic.c
+  src/cell.c
+  src/debug.c
+  src/delaunay.c
+  src/hall_symbol.c
+  src/kgrid.c
+  src/kpoint.c
+  src/mathfunc.c
+  src/niggli.c
+  src/pointgroup.c
+  src/primitive.c
+  src/refinement.c
+  src/sitesym_database.c
+  src/site_symmetry.c
+  src/spacegroup.c
+  src/spg_database.c
+  src/spglib.c
+  src/spin.c
+  src/symmetry.c
+)
+
+set(SPGLIB_PUBLIC_HDRS
+  src/spglib.h
+)
+
+set(SPGLIB_PRIVATE_HDRS
+  src/arithmetic.h
+  src/cell.h
+  src/debug.h
+  src/delaunay.h
+  src/hall_symbol.h
+  src/kgrid.h
+  src/kpoint.h
+  src/mathfunc.h
+  src/niggli.h
+  src/pointgroup.h
+  src/primitive.h
+  src/refinement.h
+  src/sitesym_database.h
+  src/site_symmetry.h
+  src/spacegroup.h
+  src/spg_database.h
+  src/spin.h
+  src/symmetry.h
+)
+
+add_library(spglib STATIC ${SPGLIB_SRCS} ${SPGLIB_PUBLIC_HDRS}
+            ${SPGLIB_PRIVATE_HDRS})
+
+# Suppress spglib warnings
+set_target_properties(spglib PROPERTIES COMPILE_FLAGS "-w")
+
+# Set PIC flag
+set_target_properties(spglib PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+  install(TARGETS spglib ARCHIVE DESTINATION lib)
+  install(FILES ${SPGLIB_PUBLIC_HDRS} DESTINATION include/spglib)
+endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -82,6 +82,10 @@ if(BUILD_AVOGADRO OR BUILD_MONGOCHEM)
   endif()
 endif()
 
+if(BUILD_AVOGADRO)
+  include(External_spglib)
+endif()
+
 if(ENABLE_TESTING)
   if(USE_SYSTEM_GTEST)
     find_package(GTest REQUIRED)


### PR DESCRIPTION
Spglib is downloaded from sourceforge and compiled, and then a static
library is generated. The static library is installed as 'libspglib.a'
into prefix/lib, and the primary header file 'spglib.h' is installed
into prefix/include/spglib.