### PR TITLE
Libmsym

### DIFF
--- a/cmake/External_avogadrolibs.cmake
+++ b/cmake/External_avogadrolibs.cmake
@@ -11,7 +11,7 @@ if(BUILD_MOLEQUEUE)
 else()
   set(_molequeue "OFF")
 endif()
-add_optional_deps(_deps "eigen" "glew")
+add_optional_deps(_deps "eigen" "glew" "libmsym")
 
 if(USE_VTK)
   add_optional_deps(_deps "VTK")

--- a/cmake/External_libmsym.cmake
+++ b/cmake/External_libmsym.cmake
@@ -1,8 +1,8 @@
 set(_build "${CMAKE_CURRENT_BINARY_DIR}/libmsym")
 
 ExternalProject_Add(libmsym
-  GIT_REPOSITORY "https://github.com/mcodev31/libmsym"
-  GIT_TAG "0c47befe4a1cd05cbba1aa561b914be926e5ced7"
+  GIT_REPOSITORY "https://github.com/ghutchis/libmsym"
+  GIT_TAG "43d48f1476f0e73563e0b16a7f153c61d08dedc7"
   DOWNLOAD_DIR ${download_dir}
   BINARY_DIR ${_build}
   CMAKE_CACHE_ARGS

--- a/cmake/External_libmsym.cmake
+++ b/cmake/External_libmsym.cmake
@@ -1,0 +1,14 @@
+set(_build "${CMAKE_CURRENT_BINARY_DIR}/libmsym")
+
+ExternalProject_Add(libmsym
+  GIT_REPOSITORY "https://github.com/mcodev31/libmsym"
+  GIT_TAG "0c47befe4a1cd05cbba1aa561b914be926e5ced7"
+  DOWNLOAD_DIR ${download_dir}
+  BINARY_DIR ${_build}
+  CMAKE_CACHE_ARGS
+    ${OpenChemistry_DEFAULT_ARGS}
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+    -DMSYM_NO_VLA_SUPPORT:BOOL=TRUE
+    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  )

--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -42,7 +42,7 @@ set(gtest_md5 "4ff6353b2560df0afecfbda3b2763847")
 # hdf5
 list(APPEND projects hdf5)
 set(hdf5_version "1.8.12")
-set(hdf5_url "http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz")
+set(hdf5_url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz")
 set(hdf5_md5 "d804802feb99b87fc668a90e6fa34411")
 
 # mongodb

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 
 if(BUILD_AVOGADRO)
   include(External_spglib)
+  include(External_libmsym)
 endif()
 
 if(ENABLE_TESTING)


### PR DESCRIPTION
Adds support for libmsym project without VLA support (i.e., a restricted set of functions useful for Avogadro)