### PR TITLE
libarchive dependency build: turn off tests

### DIFF
--- a/cmake/libarchive.CMakeLists.txt
+++ b/cmake/libarchive.CMakeLists.txt
@@ -186,7 +186,7 @@ OPTION(ENABLE_CAT_SHARED "Enable dynamic build of cat" FALSE)
 OPTION(ENABLE_XATTR "Enable extended attribute support" ON)
 OPTION(ENABLE_ACL "Enable ACL support" ON)
 OPTION(ENABLE_ICONV "Enable iconv support" OFF)
-OPTION(ENABLE_TEST "Enable unit and regression tests" ON)
+OPTION(ENABLE_TEST "Enable unit and regression tests" OFF)
 OPTION(ENABLE_COVERAGE "Enable code coverage (GCC only, automatically sets ENABLE_TEST to ON)" FALSE)
 OPTION(ENABLE_INSTALL "Enable installing of libraries" ON)
 


### PR DESCRIPTION
Building the libarchive tests with Visual Studio 2017 and ninja on
AppVeyor fails for some reason with the following error message:

test_utils\test_main.c(2118): error C2220: warning treated as error - no 'object' file generated

Turning off the tests (which seem unnecessary for us) fixes this
issue.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>