### PR TITLE
The Qt Testing repository has moved

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = git://github.com/Kitware/VTK.git
 [submodule "thirdparty/qttesting"]
 	path = thirdparty/qttesting
-	url = git://paraview.org/QtTesting.git
+	url = git://github.com/Kitware/QtTesting.git
 [submodule "thirdparty/protobuf"]
 	path = thirdparty/protobuf
 	url = git://github.com/OpenChemistry/protobuf.git


### PR DESCRIPTION
The old git hosting was turned off, and that was causing the initial
checkout to fail for Qt Testing.

Signed-off-by: Marcus D. Hanwell <marcus.hanwell@kitware.com>