### PR TITLE
Add an option to build yaehmop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "thirdparty/pybind11"]
 	path = thirdparty/pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "thirdparty/yaehmop"]
+	path = thirdparty/yaehmop
+	url = https://github.com/greglandrum/yaehmop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option(BUILD_AVOGADRO_CLIENT_SERVER
 option(USE_VTK "Enable libraries that use VTK in Avogadro" OFF)
 option(USE_HDF5 "Enable functionality that requires HDF5" OFF)
 option(USE_PYTHON "Enable functionality that requires Python" OFF)
+option(USE_YAEHMOP "Enable functionality that requires Yaehmop" OFF)
 
 if(USE_PYTHON)
   find_package(PythonInterp 3 REQUIRED)

--- a/cmake/External_yaehmop.cmake
+++ b/cmake/External_yaehmop.cmake
@@ -1,0 +1,15 @@
+set(_source "${CMAKE_CURRENT_SOURCE_DIR}/yaehmop/tightbind")
+set(_build "${CMAKE_CURRENT_BINARY_DIR}/yaehmop")
+set(_install "${OpenChemistry_INSTALL_PREFIX}")
+
+unset(_deps)
+
+ExternalProject_Add(yaehmop
+  SOURCE_DIR ${_source}
+  BINARY_DIR ${_build}
+  INSTALL_DIR ${_install}
+  CMAKE_CACHE_ARGS
+    ${OpenChemistry_DEFAULT_ARGS}
+  DEPENDS
+    ${_deps}
+  )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -96,6 +96,10 @@ if(BUILD_AVOGADRO AND USE_VTK)
   endif()
 endif()
 
+if(BUILD_AVOGADRO AND USE_YAEHMOP)
+  include(External_yaehmop)
+endif()
+
 if(BUILD_MOLEQUEUE AND BUILD_MOLEQUEUE_UIT)
   include(External_kdsoap)
 endif()


### PR DESCRIPTION
If the cmake option `USE_YAEHMOP` is on (off by default), yaehmop
will be built and installed for use in avogadrolibs (and potentially other submodules).

This has been tested with avogadrolibs: I am able
to include a yaehmop header file and link to yaehmop.

@ghutchis @cryos Greg Landrum recently made yaehmop [simpler to compile](https://github.com/greglandrum/yaehmop/pull/20), and he added the ability to [use yaehmop as a library](https://github.com/greglandrum/yaehmop/pull/23). This PR adds yaehmop as a submodule and builds it (without blas and lapack currently) so that we can run it in avogadrolibs.