### PR TITLE
Fix libxml2 break for Windows (typed 2.9.8 when 2.9.10 is latest)

### DIFF
--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -45,9 +45,9 @@ set(pcre_md5 "3bcd2441024d00009a5fee43f058987c")
 
 # libxml2
 list(APPEND projects libxml2)
-set(libxml2_version "2.9.8")
-set(libxml2_url "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.10/libxml2-v${libxml2_version}.tar.gz")
-set(libxml2_md5 "b786e353e2aa1b872d70d5d1ca0c740d")
+set(libxml2_version "2.9.10")
+set(libxml2_url "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${libxml2_version}/libxml2-v${libxml2_version}.tar.gz")
+set(libxml2_md5 "2b717cf366c4397b0b6353142ccd8e1c")
 
 # Zlib
 list(APPEND projects zlib)


### PR DESCRIPTION
Change-Id: Iedf791986ff376dfc14b306a4c83d9dfdd180c72
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>