### PR TITLE
Fix md5 hash - download from curl instead Safari

### DIFF
--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -45,9 +45,9 @@ set(pcre_md5 "3bcd2441024d00009a5fee43f058987c")
 
 # libxml2
 list(APPEND projects libxml2)
-set(libxml2_version "2.9.8")
-set(libxml2_url "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.10/libxml2-v${libxml2_version}.tar.gz")
-set(libxml2_md5 "b786e353e2aa1b872d70d5d1ca0c740d")
+set(libxml2_version "2.9.10")
+set(libxml2_url "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${libxml2_version}/libxml2-v${libxml2_version}.tar.gz")
+set(libxml2_md5 "b18faee9173c3378c910f6d7d1493115")
 
 # Zlib
 list(APPEND projects zlib)


### PR DESCRIPTION
Change-Id: I9402f3c7fe6a40a78a444062ae1353622e36068e
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>