### PR TITLE
Switch glew to new GitHub repo and bump to 2.2.0

### DIFF
--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -15,9 +15,9 @@ set(eigen_md5 "609286804b0f79be622ccf7f9ff2b660")
 
 # glew
 list(APPEND projects glew)
-set(glew_version "2.1.0")
-set(glew_url "https://sourceforge.net/projects/glew/files/glew/${glew_version}/glew-${glew_version}.tgz/download")
-set(glew_md5 "b2ab12331033ddfaa50dc39345343980")
+set(glew_version "2.2.0")
+set(glew_url "https://github.com/nigels-com/glew/archive/glew-${glew_version}.tgz")
+set(glew_md5 "3579164bccaef09e36c0af7f4fd5c7c7")
 
 # gtest
 list(APPEND projects gtest)


### PR DESCRIPTION
Seems to provide more stable download than SourceForge on
GitHub actions (no surprise)

Change-Id: I24e310de667b37c3c39b8b5e34991934a1eb9e9f