### PR TITLE
Migrate to libarchive 3.5.1 (latest)

### DIFF
--- a/cmake/External_libarchive.cmake
+++ b/cmake/External_libarchive.cmake
@@ -11,9 +11,6 @@ ExternalProject_Add(libarchive
   URL ${libarchive_url}
   URL_MD5 ${libarchive_md5}
   BUILD_IN_SOURCE 1
-  PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "${_self_dir}/libarchive.CMakeLists.txt"
-    "<SOURCE_DIR>/CMakeLists.txt"
-	CMAKE_ARGS
-	  -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
 )

--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -69,9 +69,9 @@ set(spglib_md5 "1933e2252a0e708951ee476eb93f6495")
 
 # libarchive
 list(APPEND projects libarchive)
-set(libarchive_version "3.3.3")
+set(libarchive_version "3.5.1")
 set(libarchive_url "https://github.com/libarchive/libarchive/archive/v${libarchive_version}.tar.gz")
-set(libarchive_md5 "c591a2781609e7d0c47049a0f061ce99")
+set(libarchive_md5 "742a47936955f280b9dc712ac544f8ec")
 
 # msgpackc
 list(APPEND projects msgpackc)


### PR DESCRIPTION
Remove the custom CMake which breaks the build

Change-Id: Ie63f36bcebae762b06fefe1c5468845371ebf612
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>