### PR TITLE
Prefer https transport over SSH for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "molequeue"]
 	path = molequeue
-	url = git@github.com:OpenChemistry/molequeue.git
+	url = https://github.com/OpenChemistry/molequeue.git
 [submodule "avogadrolibs"]
 	path = avogadrolibs
-	url = git@github.com:OpenChemistry/avogadrolibs.git
+	url = https://github.com/OpenChemistry/avogadrolibs.git
 [submodule "avogadrodata"]
 	path = avogadrodata
-	url = git@github.com:OpenChemistry/avogadrodata.git
+	url = https://github.com/OpenChemistry/avogadrodata.git
 [submodule "avogadroapp"]
 	path = avogadroapp
-	url = git@github.com:OpenChemistry/avogadroapp.git
+	url = https://github.com/OpenChemistry/avogadroapp.git
 [submodule "thirdparty/VTK"]
 	path = thirdparty/VTK
-	url = git@github.com:Kitware/VTK.git
+	url = https://github.com/Kitware/VTK.git
 [submodule "thirdparty/qttesting"]
 	path = thirdparty/qttesting
 	url = https://gitlab.kitware.com/paraview/qttesting.git
 [submodule "thirdparty/protobuf"]
 	path = thirdparty/protobuf
-	url = git@github.com:OpenChemistry/protobuf.git
+	url = https://github.com/OpenChemistry/protobuf.git
 [submodule "thirdparty/protocall"]
 	path = thirdparty/protocall
-	url = git@github.com:OpenChemistry/protocall.git
+	url = https://github.com/OpenChemistry/protocall.git
 [submodule "avogadrogenerators"]
 	path = avogadrogenerators
-	url = git@github.com:openchemistry/avogenerators.git
+	url = https://github.com/openchemistry/avogenerators.git
 [submodule "thirdparty/pybind11"]
 	path = thirdparty/pybind11
 	url = https://github.com/pybind/pybind11.git
@@ -33,7 +33,7 @@
 	url = https://github.com/greglandrum/yaehmop
 [submodule "molecules"]
 	path = molecules
-	url = git@github.com:OpenChemistry/molecules.git
+	url = https://github.com/OpenChemistry/molecules.git
 [submodule "crystals"]
 	path = crystals
-	url = git@github.com:OpenChemistry/crystals.git
+	url = https://github.com/OpenChemistry/crystals.git


### PR DESCRIPTION
This is friendlier for the majority, and those who are developing should set up the right remote for pushing topic branches etc.