### PR TITLE
Changes required for flatpak build to succeed using superbuild strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ include(BuildLocation)
 
 include(ExternalProject)
 include(projects)
+# Allow choice of where download_dir should be.
+option(DOWNLOAD_TO_SOURCE_DIR "Download external dependency source archives to CMAKE_CURRENT_SOURCE_DIR/Downloads" OFF)
+option(DOWNLOAD_TO_BINARY_DIR "Download external dependency source archives to CMAKE_CURRENT_BINARY_DIR/Downloads" OFF)
 include(download_dir)
 
 # Set up a few default arguments for all projects, such as the install prefix,

--- a/cmake/External_libmsym.cmake
+++ b/cmake/External_libmsym.cmake
@@ -1,10 +1,11 @@
 set(_build "${CMAKE_CURRENT_BINARY_DIR}/libmsym")
+set(libmsym_source  "${CMAKE_CURRENT_BINARY_DIR}/libmsym-0.2.3-paper")
 
 ExternalProject_Add(libmsym
-  GIT_REPOSITORY "https://github.com/mcodev31/libmsym.git"
-  GIT_TAG "0c47befe4a1cd05cbba1aa561b914be926e5ced7"
   DOWNLOAD_DIR ${download_dir}
-  BINARY_DIR ${_build}
+  SOURCE_DIR "${libmsym_source}"
+  URL ${libmsym_url}
+  URL_MD5 ${libmsym_md5}
   CMAKE_CACHE_ARGS
     ${OpenChemistry_DEFAULT_ARGS}
   CMAKE_ARGS
@@ -12,4 +13,4 @@ ExternalProject_Add(libmsym
     -DMSYM_NO_VLA_SUPPORT:BOOL=TRUE
     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     -DINSTALL_BIN_DIR:PATH=bin
-  )
+)

--- a/cmake/download_dir.cmake
+++ b/cmake/download_dir.cmake
@@ -5,12 +5,14 @@
 # Downloads subdir in the build tree.
 #
 if(NOT DEFINED download_dir)
-  if(NOT "$ENV{HOME}" STREQUAL "" AND EXISTS "$ENV{HOME}/Downloads")
+  if(DOWNLOAD_TO_SOURCE_DIR AND NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "")
+    set(download_dir "${CMAKE_CURRENT_SOURCE_DIR}/Downloads")
+  elseif(DOWNLOAD_TO_BINARY_DIR AND NOT "${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "")
+    set(download_dir "${CMAKE_CURRENT_BINARY_DIR}/Downloads")
+  elseif(NOT "$ENV{HOME}" STREQUAL "" AND EXISTS "$ENV{HOME}/Downloads")
     set(download_dir "$ENV{HOME}/Downloads")
   elseif(NOT "$ENV{USERPROFILE}" STREQUAL "" AND EXISTS "$ENV{USERPROFILE}/Downloads")
     set(download_dir "$ENV{USERPROFILE}/Downloads")
-  elseif(NOT "${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "")
-    set(download_dir "${CMAKE_CURRENT_BINARY_DIR}/Downloads")
   else()
     message(FATAL_ERROR "unexpectedly empty CMAKE_CURRENT_BINARY_DIR")
   endif()

--- a/cmake/projects.cmake
+++ b/cmake/projects.cmake
@@ -78,3 +78,9 @@ list(APPEND projects mmtf-cpp)
 set(mmtfcpp_version "1.1.0")
 set(mmtfcpp_url "https://github.com/rcsb/mmtf-cpp/archive/v${mmtfcpp_version}.tar.gz")
 set(mmtfcpp_md5 "ec961ff406a1636b4c5a25de7d9bd47b")
+
+# libmsym
+list(APPEND projects libmsym)
+set(libmsym_version "0.2.3-paper")
+set(libmsym_url "https://github.com/mcodev31/libmsym/archive/refs/tags/v${libmsym_version}.tar.gz")
+set(libmsym_md5 "1221f9f0b1efefe061b0afbf8cf72481")


### PR DESCRIPTION
Also applicable for any build that needs to occur without network access, and therefore external sources have to be downloaded prior